### PR TITLE
修复匿名SMB共享时，无法修改下载文件的问题。

### DIFF
--- a/aria2/aria2/scripts/aria2_config.sh
+++ b/aria2/aria2/scripts/aria2_config.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+opkg update && opkg install sudo &
 export KSROOT=/koolshare
 source $KSROOT/scripts/base.sh
 eval `dbus export aria2`
@@ -21,7 +22,7 @@ EOF
 }
 
 start_aria2(){
-	/koolshare/aria2/aria2c --conf-path=/tmp/aria2.conf -D >/dev/null 2>&1 &
+	sudo -u nobody /koolshare/aria2/aria2c --conf-path=/tmp/aria2.conf -D >/dev/null 2>&1 &
 }
 
 kill_aria2(){


### PR DESCRIPTION
用nobody方式运行aria2，让匿名SMB共享能拥有修改aria2下载的文件权限。