### PR TITLE
fix chromecast related

### DIFF
--- a/koolss/koolss/ss/ssstart.sh
+++ b/koolss/koolss/ss/ssstart.sh
@@ -1001,6 +1001,7 @@ start_ss_redir(){
 flush_nat(){
 	echo_date 尝试先清除已存在的iptables规则，防止重复添加
 	# flush iptables rules
+	iptables -t nat -D PREROUTING -p udp -s $(get_lan_cidr) --dport 53 -j DNAT --to $lan_ipaddr
 	iptables -t nat -D OUTPUT -j SHADOWSOCKS > /dev/null 2>&1
 	iptables -t nat -D OUTPUT -p tcp -m set --match-set router dst -j REDIRECT --to-ports 3333 > /dev/null 2>&1
 	nat_indexs=`iptables -nvL PREROUTING -t nat |sed 1,2d | sed -n '/SHADOWSOCKS/='|sort -r`
@@ -1306,6 +1307,7 @@ chromecast(){
 	chromecast_nu=`iptables -t nat -L PREROUTING -v -n --line-numbers|grep "dpt:53"|awk '{print $1}'`
 	is_right_lanip=`iptables -t nat -L PREROUTING -v -n --line-numbers|grep "dpt:53" |grep "$lan_ipaddr"`
 	if [ "$ss_basic_chromecast" == "1" ];then
+	iptables -t mangle -I SHADOWSOCKS_GAM -p udp --dport 53 -j RETURN
 		if [ -z "$chromecast_nu" ]; then
 			iptables -t nat -A PREROUTING -p udp -s $(get_lan_cidr) --dport 53 -j DNAT --to $lan_ipaddr >/dev/null 2>&1
 			echo_date $LOG1


### PR DESCRIPTION
1.fix chromecast iptables not flushed after reboot or close.
2.fix chromecast with game mode.

Already tested,all perfect.
Under game mode:
With chromecast off,UDP53 go through ss-redir.
With chromecast on,UDP53 DNAT to ledeUDP53 without a problem.