### PR TITLE
删除影响用户操作的多余css动画

### DIFF
--- a/softcenter/softcenter/webs/soft-center.asp
+++ b/softcenter/softcenter/webs/soft-center.asp
@@ -567,7 +567,7 @@ function getSoftCenter(obj){
 						bgimg1 = softcenterUrl+"/softcenter/softcenter/webs/res/icon-"+appname+"-bg.png";
 						bgimg = '/res/icon-'+appname+'-bg.png';
 						appimg = '/res/icon-'+appname+'.png';
-						vhtml1 += '<div class="apps" style="background:url('+bgimg1+'), url('+bgimg+');" onmouseover="change1(this);" onmouseout="change2(this);">'+
+						vhtml1 += '<div class="apps" style="background:url('+bgimg1+'), url('+bgimg+');" >'+
 						'<a href="'+aurl+'" title="'+title+'\n'+description+'">'+
 							'<div class="infos">'+
 								'<img class="appimg" src="'+appimg1+'" onerror="this.onerror=null;this.src=\'' + appimg + '\';"/></div>'+
@@ -583,7 +583,7 @@ function getSoftCenter(obj){
 						appimg = softcenterUrl+"/softcenter/softcenter/webs/res/icon-"+appname+".png";
 						bgimg = softcenterUrl+"/softcenter/softcenter/webs/res/icon-"+appname+"-bg.png";
 						appButton = '<button type="button" value="'+appname+'" onclick="appinstall(this)" class="btn btn-primary">安装</button>';
-						vhtml2 += '<div title="'+title+'\n'+description+'" class="apps" style="background:url('+bgimg+');" onmouseover="change1(this);" onmouseout="change2(this);">'+
+						vhtml2 += '<div title="'+title+'\n'+description+'" class="apps" style="background:url('+bgimg+');" >'+
 							'<div class="infos">'+
 								'<img class="appimg" src="'+appimg+'"/></div>'+
 								'<div class="app-name"><p>'+title+'</p>'+
@@ -644,7 +644,7 @@ function getLocalApp(obj){
 			appimg = "/res/icon-"+name+".png";
 			bgimg = "/res/icon-"+name+"-bg.png";
 			appButton = '<button type="button" value="'+name+'" onclick="appuninstall(this)" class="btn btn-danger">卸载</button>';
-			vhtml1 += '<div class="apps" style="background:url('+bgimg+');" onmouseover="change1(this);" onmouseout="change2(this);"><a href="'+aurl+'" title="'+name+'\n'+description+'"><div class="infos"><img class="appimg" src="'+appimg+'"/></div><div class="app-name"><p>'+name+'</p><p>'+description+'</p></div></a><div class="appDesc">'+appButton+'</div></div>';
+			vhtml1 += '<div class="apps" style="background:url('+bgimg+');"><a href="'+aurl+'" title="'+name+'\n'+description+'"><div class="infos"><img class="appimg" src="'+appimg+'"/></div><div class="app-name"><p>'+name+'</p><p>'+description+'</p></div></a><div class="appDesc">'+appButton+'</div></div>';
 		}  						
 	}
 	$("#app1-server1-basic-tab").html('<i class="icon-system"></i> 已安装（'+j+'）');


### PR DESCRIPTION
软件中心的卡片, 在鼠标 mouseover / mouseout 会添加 animate.css 的 翻转 css 动画, 极大影响用户体验 跟浪费用户时间, 用户在鼠标移动上去之后还要等这个css动画, 一两个可以, 多了就非常恶心,  强烈建议删除掉, 谋求更好的视觉效果. 例如:hover / :active  之后 box-shadow  高光都行