### PR TITLE
删除影响用户操作的多余css动画

### DIFF
--- a/softcenter/softcenter/webs/soft-center.asp
+++ b/softcenter/softcenter/webs/soft-center.asp
@@ -280,9 +280,9 @@ function change1(obj){
 	}
 	if(anmstatus != obj){
 		anmstatus = obj;
-		$(obj).stop().removeClass('animated flipInY').addClass('animated flipInY').one('animationend webkitAnimationEnd oAnimationEnd', function(){
-			$(obj).removeClass('animated flipInY');
-    	});	
+		// $(obj).stop().removeClass('animated flipInY').addClass('animated flipInY').one('animationend webkitAnimationEnd oAnimationEnd', function(){
+		// 	$(obj).removeClass('animated flipInY');
+    	// });	
 	}
 	$(obj).find('.appDesc').show();
 	$(obj).find('.app-name').width('130px');


### PR DESCRIPTION
软件中心的卡片, 在鼠标 mouseover / mouseout 会添加 animate.css 的 翻转 css 动画, 极大影响用户体验 跟浪费用户时间, 用户在鼠标移动上去之后还要等这个css动画, 一两个可以, 多了就非常恶心,  强烈建议删除掉, 谋求更好的视觉效果. 例如:hover / :active  之后 box-shadow  高光都行. 然后...大哥, 多学学 vue 或者 react ,  less / sass 都行啊...页面写得非常糟糕