### PR TITLE
解决在软件中心安装软件提示下载文件校验不一致的BUG 去掉wget无法识别的--tries参数

### DIFF
--- a/softcenter/softcenter/scripts/ks_app_install.sh
+++ b/softcenter/softcenter/scripts/ks_app_install.sh
@@ -75,7 +75,7 @@ install_module() {
 	rm -rf "/tmp/$softcenter_installing_module"
 	dbus set softcenter_installing_status="3"
 	sleep 2
-	wget --no-check-certificate --tries=1 --timeout=15 $TAR_URL
+	wget --no-check-certificate --timeout=15 $TAR_URL
 	RETURN_CODE=$?
 
 	if [ "$RETURN_CODE" != "0" ]; then


### PR DESCRIPTION

root@Openwrt:/koolshare/scripts# wget
Usage: wget [options] <URL>
Options:
	-4				Use IPv4 only
	-6				Use IPv6 only
	-q				Turn off status messages
	-O <file>			Redirect output to file (use "-" for stdout)
	-P <dir>			Set directory for output files
	--user=<user>			HTTP authentication username
	--password=<password>		HTTP authentication password
	--user-agent|-U <str>		Set HTTP user agent
	--post-data=STRING		use the POST method; send STRING as the data
	--spider|-s			Spider mode - only check file existence
	--timeout=N|-T N		Set connect/request timeout to N seconds
	--proxy=on|off|-Y on|off	Enable/disable env var configured proxy

HTTPS options:
	--ca-certificate=<cert>		Load CA certificates from file <cert>
	--no-check-certificate		don't validate the server's certificate